### PR TITLE
fix: solve login issue #95

### DIFF
--- a/libs/web/auth/data-access/src/lib/models/spotify-authorize.ts
+++ b/libs/web/auth/data-access/src/lib/models/spotify-authorize.ts
@@ -29,7 +29,7 @@ export class SpotifyAuthorize {
     const params = new URLSearchParams({
       client_id: this.CLIENT_ID,
       redirect_uri: `${window.location.origin}/`,
-      scope: encodeURIComponent(this.SCOPES.join(' ')),
+      scope: this.SCOPES.join(' '),
       response_type: 'token'
     });
     return `${this.SPOTIFY_AUTHORIZE_URL}?${params.toString()}`;


### PR DESCRIPTION
Hi Trung

I came across this repo by chance and was enthusiastic about the idea. Unfortunately, when I tried it out, it didn't work and I ended up on this error page (it's German, because this is my browser language as a Swiss).

![image](https://github.com/trungvose/angular-spotify/assets/112761658/d16643d1-d8bd-4832-b6e8-c55bff9f6704)

The error apparently only occurs if you are already logged in to Spotify and only want to grant access to the app instead of logging in additionally. This is because Spotify does not accept plus signs that are coded with “%2520” (perhaps they used to accept it that way). However, everything seems to be OK if you don't encode the whole thing and just leave the '+' characters as they are.

![image](https://github.com/trungvose/angular-spotify/assets/112761658/728d488f-d226-45d7-9dd3-0f5388734169)

This seems to correspond with the issue #95. Thus, I have also left a comment there.

I hope I have been able to make a small contribution and, as a rookie, have not drawn a completely wrong conclusion 😅. If so, I have a question if you can give me a pro tip on how to get the Starstruck Achievment as easy as possible but legit (e.g. for my school project TouGH-Vault). I doubt that I have earned any form of endorsement, because that would probably be the fastest way, but prove me wrong 🙂.

All the best
JZEL